### PR TITLE
Produce multi-channel histograms

### DIFF
--- a/BH_SPC150.c
+++ b/BH_SPC150.c
@@ -70,6 +70,8 @@ static void PopulateDefaultParameters(struct BH_PrivateData *data)
 	data->tacRate = 0.0;
 	data->adcRate = 0.0;
 
+	data->channelMask = 1; // Enable channel 0 only by default
+
 	for (int i = 0; i < NUM_MARKER_BITS; ++i) {
 		data->markerActiveEdges[i] = MarkerPolarityRisingEdge;
 	}

--- a/BH_SPC150Private.h
+++ b/BH_SPC150Private.h
@@ -8,9 +8,12 @@
 struct AcqState; // Defined in C++
 
 
-// As far as I can tell this is uniform across all BH SPC models supporting
-// FIFO mode and external markers.
+// This is uniform across all BH SPC models supporting FIFO mode and external
+// markers.
 #define NUM_MARKER_BITS 4
+
+// All BH SPC models supporting FIFO mode have 4 routing bits in FIFO mode.
+#define MAX_NUM_CHANNELS 16
 
 
 enum MarkerPolarity {
@@ -49,6 +52,8 @@ struct BH_PrivateData
 	double cfdRate;
 	double tacRate;
 	double adcRate;
+
+	uint16_t channelMask;
 
 	// External marker configuration
 	enum MarkerPolarity  markerActiveEdges[NUM_MARKER_BITS];

--- a/DataStream.hpp
+++ b/DataStream.hpp
@@ -9,6 +9,7 @@
 
 #include <OpenScanDeviceLib.h>
 
+#include <bitset>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -17,6 +18,7 @@
 
 std::tuple<std::shared_ptr<EventStream<BHSPCEvent>>, std::future<void>>
 SetUpProcessing(uint32_t width, uint32_t height, uint32_t maxFrames,
+	std::bitset<16> channelMask,
 	int32_t lineDelay, uint32_t lineTime, uint32_t lineMarkerBit,
 	OScDev_Acquisition* acquisition, std::function<void(void)> stopFunc,
 	std::shared_ptr<DeviceEventProcessor> additionalProcessor,

--- a/FLIMEvents/include/FLIMEvents/PixelPhotonEvent.hpp
+++ b/FLIMEvents/include/FLIMEvents/PixelPhotonEvent.hpp
@@ -35,8 +35,9 @@ class BroadcastPixelPhotonProcessor : public PixelPhotonProcessor {
     std::array<std::shared_ptr<PixelPhotonProcessor>, N> downstreams;
 
 public:
+    // All downstreams must be non-null
     template <typename... T>
-    BroadcastPixelPhotonProcessor(T... downstreams) :
+    explicit BroadcastPixelPhotonProcessor(T... downstreams) :
         downstreams{ {downstreams...} }
     {}
 

--- a/FLIMEvents/include/FLIMEvents/PixelPhotonRouter.hpp
+++ b/FLIMEvents/include/FLIMEvents/PixelPhotonRouter.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "PixelPhotonEvent.hpp"
+
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+
+class PixelPhotonRouter : public PixelPhotonProcessor {
+    // Indexed by channel number
+    std::vector<std::shared_ptr<PixelPhotonProcessor>> downstreams;
+
+public:
+    // Downstreams indexed by channel number; may be null
+    template <typename... T>
+    explicit PixelPhotonRouter(T... downstreams) :
+        downstreams{ {downstreams...} }
+    {}
+
+    explicit PixelPhotonRouter(std::vector<std::shared_ptr<PixelPhotonProcessor>> downstreams) :
+        downstreams(downstreams)
+    {}
+
+    void HandleBeginFrame() override {
+        for (auto& d : downstreams) {
+            if (d) {
+                d->HandleBeginFrame();
+            }
+        }
+    }
+
+    void HandleEndFrame() override {
+        for (auto& d : downstreams) {
+            if (d) {
+                d->HandleEndFrame();
+            }
+        }
+    }
+
+    void HandlePixelPhoton(PixelPhotonEvent const& event) override {
+        auto channel = event.route;
+        std::shared_ptr<PixelPhotonProcessor> d;
+        try {
+            d = downstreams.at(channel);
+        }
+        catch (std::out_of_range const&) {
+            return;
+        }
+        if (d) {
+            d->HandlePixelPhoton(event);
+        }
+    }
+
+    void HandleError(std::string const& message) override {
+        for (auto& d : downstreams) {
+            if (d) {
+                d->HandleError(message);
+            }
+        }
+    }
+
+    void HandleFinish() override {
+        for (auto& d : downstreams) {
+            if (d) {
+                d->HandleFinish();
+            }
+        }
+    }
+};

--- a/FLIMEvents/include/meson.build
+++ b/FLIMEvents/include/meson.build
@@ -5,6 +5,7 @@ public_cpp_headers = files(
         'FLIMEvents/Histogram.hpp',
         'FLIMEvents/LineClockPixellator.hpp',
         'FLIMEvents/PixelPhotonEvent.hpp',
+        'FLIMEvents/PixelPhotonRouter.hpp',
         'FLIMEvents/PQT3DeviceEvent.hpp',
         'FLIMEvents/StreamBuffer.hpp',
         )

--- a/SDTFileWriter.hpp
+++ b/SDTFileWriter.hpp
@@ -67,7 +67,11 @@ public:
 		data.numChannels = nChannels;
 
 		channelData.resize(nChannels);
-		memset(channelData.data(), 0, nChannels * sizeof(SDTFileChannelData));
+		for (unsigned i = 0; i < nChannels; ++i) {
+			auto& chData = channelData[i];
+			memset(&chData, 0, sizeof(SDTFileChannelData));
+			chData.channel = i;
+		}
 
 		memset(&params, 0, sizeof(params));
 


### PR DESCRIPTION
This adds settings to enable/disable each of the 16 possible channels,
plus construction and saving of multi-channel histograms in the .sdt
file. The intensity image for display remains single-channel but is now
the sum of photons only from the enabled channels.