### PR TITLE
Fix spelling in SDT file metadata for opening in SdtFile and SPCM

### DIFF
--- a/src/SDTFile/SDTFile.c
+++ b/src/SDTFile/SDTFile.c
@@ -50,7 +50,7 @@ static int WriteSDTIdentification(FILE *fp, const struct SDTFileData *data) {
         // consider removing.
         snprintf(
             buf, bufSize,
-            "*IDENTIFICAION" NEWLINE "  ID        : %s" NEWLINE
+            "*IDENTIFICATION" NEWLINE "  ID        : %s" NEWLINE
             "  Title     : OpenScan FLIM Image" NEWLINE
             "  Version   : 3  980 M" NEWLINE
             "  Revision  : %u bits ADC" NEWLINE "  Date      : %s" NEWLINE


### PR DESCRIPTION
This fix allows OpenScan SDT files to be opened in BH SPCM and with "SdtFile" from Christophe Gohlke's sdtfile library.